### PR TITLE
Switch to 18080 in examples

### DIFF
--- a/examples/httprouter/main.go
+++ b/examples/httprouter/main.go
@@ -5,20 +5,20 @@ Example using github.com/julienschmidt/httprouter:
 
 	$ go run main.go &
 
-	$ curl -kE ../test-fixtures/client1.pem https://localhost:8080/
+	$ curl -kE ../test-fixtures/client1.pem https://localhost:18080/
 	Welcome!
 
-	$ curl -kE ../test-fixtures/client2.pem https://localhost:8080/
+	$ curl -kE ../test-fixtures/client2.pem https://localhost:18080/
 	Welcome!
 
-	$ curl -kE ../test-fixtures/client1.pem https://localhost:8080/hello/foo
+	$ curl -kE ../test-fixtures/client1.pem https://localhost:18080/hello/foo
 	hello, foo!
 
-	$ curl -kE ../test-fixtures/client2.pem https://localhost:8080/hello/foo
+	$ curl -kE ../test-fixtures/client2.pem https://localhost:18080/hello/foo
 	Authentication Failed
 
 	### NOTE: curl on macOS might require using the .p12 file instead of the .pem:
-	$ curl -kE ../test-fixtures/client.p12:password https://localhost:8080/
+	$ curl -kE ../test-fixtures/client.p12:password https://localhost:18080/
 */
 
 import (
@@ -63,7 +63,7 @@ func main() {
 	cfg := certutils.TLSServerConfig{
 		CertPool:    caCerts,
 		BindAddress: "",
-		Port:        8080,
+		Port:        18080,
 		Router:      router,
 	}
 

--- a/examples/net_http/main.go
+++ b/examples/net_http/main.go
@@ -5,14 +5,14 @@ Example using go stdlib net/http ListenAndServeTLS():
 
 	$ go run main.go &
 
-	$ curl -kE ../test-fixtures/client1.pem https://localhost:8080/
+	$ curl -kE ../test-fixtures/client1.pem https://localhost:18080/
 	hello, world!
 
-	$ curl -kE ../test-fixtures/client2.pem https://localhost:8080/
+	$ curl -kE ../test-fixtures/client2.pem https://localhost:18080/
 	Authentication Failed
 
 	### NOTE: curl on macOS might require using the .p12 file instead of the .pem:
-	$ curl -kE ../test-fixtures/client1.p12:password https://localhost:8080/
+	$ curl -kE ../test-fixtures/client1.p12:password https://localhost:18080/
 */
 
 import (
@@ -43,7 +43,7 @@ func main() {
 	cfg := certutils.TLSServerConfig{
 		CertPool:    caCerts,
 		BindAddress: "",
-		Port:        8080,
+		Port:        18080,
 		Router:      router,
 	}
 


### PR DESCRIPTION
Simple change. I was having issues with curl on my Mac, so switched to running the examples on my onebox, but that already has port 8080 bound to tomcat, so needed to change the port number. I think others might run into this.