### PR TITLE
[WIP] Go stdlib net/rpc support

### DIFF
--- a/certutils/certutils.go
+++ b/certutils/certutils.go
@@ -9,6 +9,27 @@ import (
 	"net/http"
 )
 
+// TLSRPCServerConfig is the configuration you use to create a TLSRPCServer
+type TLSRPCServerConfig struct {
+	CertPool    *x509.CertPool
+	BindAddress string
+	Port        int
+}
+
+// NewTLSServer sets up a Pantheon(TM) RPC TLS server (_not_ the HTTP protocol) that requires and verifies peer cert.
+// func NewTLSRPCServer(config TLSRPCServerConfig) *http.Server {
+// 	server := &http.Server{
+// 		TLSConfig: &tls.Config{
+// 			ClientAuth: tls.RequireAndVerifyClientCert,
+// 			ClientCAs:  config.CertPool,
+// 		},
+// 		Addr:    fmt.Sprintf("%s:%d", config.BindAddress, config.Port),
+// 		Handler: config.Router,
+// 	}
+// 	server.TLSConfig.BuildNameToCertificate()
+// 	return server
+// }
+
 // TLSServerConfig is the configuration you use to create a TLSServer
 type TLSServerConfig struct {
 	CertPool    *x509.CertPool
@@ -17,7 +38,7 @@ type TLSServerConfig struct {
 	Router      http.Handler
 }
 
-// NewTLSServer sets up a Pantheon(TM) type of tls server that Requires and Verifies peer cert
+// NewTLSServer sets up a Pantheon(TM) HTTPS TLS server that requires and verifies peer cert
 func NewTLSServer(config TLSServerConfig) *http.Server {
 	// Setup client authentication
 	server := &http.Server{
@@ -48,7 +69,7 @@ func LoadKeyCertFiles(keyFile, certFile string) (tls.Certificate, error) {
 }
 
 // LoadCACertFile reads in a CA cert file that may contain multiple certs
-// and gives  you back a proper x509.CertPool for your fun and proffit
+// and gives you back a proper x509.CertPool for your fun and profit
 func LoadCACertFile(cert string) (*x509.CertPool, error) {
 	// validate caCert, and setup certpool
 	ca, err := ioutil.ReadFile(cert)

--- a/examples/go_rpc/client.go
+++ b/examples/go_rpc/client.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"crypto/tls"
+	"log"
+	"net/rpc"
+
+	"github.com/pantheon-systems/go-certauth/certutils"
+)
+
+func main() {
+	clientCert, err := tls.LoadX509KeyPair("../test-fixtures/client1.crt", "../test-fixtures/client1.key")
+	if err != nil {
+		log.Fatalf("client: loadkeys: %s", err)
+	}
+	caCerts, err := certutils.LoadCACertFile("../test-fixtures/ca.crt")
+	if err != nil {
+		log.Fatalf("Unable to load ca.crt: %s", err)
+	}
+	config := tls.Config{
+		Certificates: []tls.Certificate{clientCert},
+		RootCAs:      caCerts,
+	}
+	conn, err := tls.Dial("tcp", "127.0.0.1:18088", &config)
+	if err != nil {
+		log.Fatalf("client: dial: %s", err)
+	}
+	defer conn.Close()
+	log.Println("client: connected to: ", conn.RemoteAddr())
+	rpcClient := rpc.NewClient(conn)
+	res := new(Result)
+	if err := rpcClient.Call("Foo.Bar", "twenty-three", &res); err != nil {
+		log.Fatal("Failed to call RPC", err)
+	}
+	log.Printf("Returned result is %d", res.Data)
+}
+
+type Result struct {
+	Data int
+}

--- a/examples/go_rpc/main.go
+++ b/examples/go_rpc/main.go
@@ -1,0 +1,99 @@
+package main
+
+/*
+Example using go stdlib net/rpc:
+
+    $ go run main.go &
+
+    $ curl -kE ../test-fixtures/client1.pem https://localhost:18088/
+    hello, world!
+
+    $ curl -kE ../test-fixtures/client2.pem https://localhost:18088/
+    Authentication Failed
+
+    ### NOTE: curl on macOS might require using the .p12 file instead of the .pem:
+    $ curl -kE ../test-fixtures/client1.p12:password https://localhost:18088/
+*/
+
+import (
+	"crypto/rand"
+	"crypto/tls"
+	"log"
+	"net"
+	"net/rpc"
+
+	"github.com/pantheon-systems/go-certauth/certutils"
+)
+
+func main() {
+	if err := rpc.Register(new(Foo)); err != nil {
+		log.Fatal("Failed to register RPC method")
+	}
+
+	caCerts, err := certutils.LoadCACertFile("../test-fixtures/ca.crt")
+	if err != nil {
+		log.Fatalf("Unable to load ca.crt: %s", err)
+	}
+
+	serverCert, err := tls.LoadX509KeyPair("../test-fixtures/server.pem", "../test-fixtures/server.pem")
+	if err != nil {
+		log.Fatalf("server: loadkeys: %s", err)
+	}
+
+	config := tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    caCerts,
+	}
+	config.Rand = rand.Reader
+	config.BuildNameToCertificate()
+	service := "127.0.0.1:18088"
+	listener, err := tls.Listen("tcp", service, &config)
+	if err != nil {
+		log.Fatalf("server: listen: %s", err)
+	}
+	log.Print("server: listening")
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			log.Printf("server: accept: %s", err)
+			break
+		}
+		log.Printf("server: accepted from %s", conn.RemoteAddr())
+		go handleClient(conn)
+	}
+}
+
+func handleClient(conn net.Conn) {
+	defer conn.Close()
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		log.Println("Error casting!")
+	}
+	err := tlsConn.Handshake()
+	if err != nil {
+		log.Fatalf("server: handshake: %s", err)
+	}
+	state := tlsConn.ConnectionState()
+	for _, a := range state.VerifiedChains {
+		log.Printf("%+v", a)
+		for _, b := range a {
+			log.Printf("%+v", b)
+		}
+	}
+	rpc.ServeConn(tlsConn)
+	log.Println("server: conn: closed")
+}
+
+type Foo bool
+
+type Result struct {
+	Data int
+}
+
+func (f *Foo) Bar(args *string, res *Result) error {
+	res.Data = len(*args)
+	log.Printf("Received %q, its length is %d", *args, res.Data)
+	//return fmt.Errorf("Whoops, error happened")
+	return nil
+}

--- a/examples/httprouter/main.go
+++ b/examples/httprouter/main.go
@@ -5,20 +5,20 @@ Example using github.com/julienschmidt/httprouter:
 
 	$ go run main.go &
 
-	$ curl -kE ../test-fixtures/client1.pem https://localhost:8080/
+	$ curl -kE ../test-fixtures/client1.pem https://localhost:18080/
 	Welcome!
 
-	$ curl -kE ../test-fixtures/client2.pem https://localhost:8080/
+	$ curl -kE ../test-fixtures/client2.pem https://localhost:18080/
 	Welcome!
 
-	$ curl -kE ../test-fixtures/client1.pem https://localhost:8080/hello/foo
+	$ curl -kE ../test-fixtures/client1.pem https://localhost:18080/hello/foo
 	hello, foo!
 
-	$ curl -kE ../test-fixtures/client2.pem https://localhost:8080/hello/foo
+	$ curl -kE ../test-fixtures/client2.pem https://localhost:18080/hello/foo
 	Authentication Failed
 
 	### NOTE: curl on macOS might require using the .p12 file instead of the .pem:
-	$ curl -kE ../test-fixtures/client.p12:password https://localhost:8080/
+	$ curl -kE ../test-fixtures/client.p12:password https://localhost:18080/
 */
 
 import (
@@ -63,7 +63,7 @@ func main() {
 	cfg := certutils.TLSServerConfig{
 		CertPool:    caCerts,
 		BindAddress: "",
-		Port:        8080,
+		Port:        18080,
 		Router:      router,
 	}
 

--- a/examples/net_http/main.go
+++ b/examples/net_http/main.go
@@ -5,14 +5,14 @@ Example using go stdlib net/http ListenAndServeTLS():
 
 	$ go run main.go &
 
-	$ curl -kE ../test-fixtures/client1.pem https://localhost:8080/
+	$ curl -kE ../test-fixtures/client1.pem https://localhost:18080/
 	hello, world!
 
-	$ curl -kE ../test-fixtures/client2.pem https://localhost:8080/
+	$ curl -kE ../test-fixtures/client2.pem https://localhost:18080/
 	Authentication Failed
 
 	### NOTE: curl on macOS might require using the .p12 file instead of the .pem:
-	$ curl -kE ../test-fixtures/client1.p12:password https://localhost:8080/
+	$ curl -kE ../test-fixtures/client1.p12:password https://localhost:18080/
 */
 
 import (
@@ -43,7 +43,7 @@ func main() {
 	cfg := certutils.TLSServerConfig{
 		CertPool:    caCerts,
 		BindAddress: "",
-		Port:        8080,
+		Port:        18080,
 		Router:      router,
 	}
 


### PR DESCRIPTION
Part of https://getpantheon.atlassian.net/browse/IO-1691

@kf6nux @joemiller @spheromak @kibra 

One of the suggestions / requirements of the CSR Generator spec is use Go's standard RPC library, which does mean we can avoid JSON marshalling/unmarshaling and potentially save some time.

We would need to do the client cert OU authorization for the RPC connection somewhere, and it seems like it would be a good idea to put it in this shared repo. However, this package would need to be modified in a few ways to support non-HTTP TLS connections as it currently assumes the existence of ResponseWriter and Request. This PR contains the proof of concept and allows access to the non-HTTP connection's verified cert chain, but I still need to finish adapting the main functions.

I'm not totally convinced that this work is worth it though - what do you guys think? Is this really easier than going for a JSON-RPC or RESTish interface and just reusing the current code here? 