### PR TITLE
implement helpers to achieve greater TLS configurations

### DIFF
--- a/certutils/certutils.go
+++ b/certutils/certutils.go
@@ -9,24 +9,73 @@ import (
 	"net/http"
 )
 
+// TLSConfigCompatLevel declares a TLS configuration level returned by the NewTLSConfig func
+type TLSConfigCompatLevel int
+
+// Based on https://blog.gopheracademy.com/advent-2016/exposing-go-on-the-internet/
+// and the Mozilla TLS recommendations: https://wiki.mozilla.org/Security/Server_Side_TLS
+const (
+	TLSCompatDefault TLSConfigCompatLevel = iota
+	TLSCompatIntermediate
+	TLSCompatModern
+)
+
+// NewTLSConfig returns a *tls.Config that is pre-configured to match (roughly)
+// the Mozilla recommended TLS specification. Different levels of security -vs- compatbility
+// can be specified via the 'level' var.
+//
+// Based on: https://blog.gopheracademy.com/advent-2016/exposing-go-on-the-internet/
+// Last updated: 2017-01-11
+func NewTLSConfig(level TLSConfigCompatLevel) *tls.Config {
+	// TLSDefault - golang's default
+	c := &tls.Config{}
+
+	switch level {
+	case TLSCompatIntermediate:
+		// Causes servers to use Go's default ciphersuite preferences, which are tuned to avoid attacks. Does nothing on clients.
+		c.PreferServerCipherSuites = true
+		// Only use curves which have assembly implementations
+		c.CurvePreferences = []tls.CurveID{
+			tls.CurveP256,
+			//tls.X25519, //TODO: enable this when everything is using go 1.8 or make this a compile-time conditional
+		}
+	case TLSCompatModern:
+		// Modern compat sets TLS_1.2 minimum version and a set of ciphers that support PFS
+		c.MinVersion = tls.VersionTLS12
+		c.CipherSuites = []uint16{
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			// TODO: enable these when everything is using go 1.8 or make this a compile-time conditional
+			// tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305, // Go 1.8 only
+			// tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,   // Go 1.8 only
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		}
+	}
+	return c
+}
+
 // TLSServerConfig is the configuration you use to create a TLSServer
 type TLSServerConfig struct {
-	CertPool    *x509.CertPool
-	BindAddress string
-	Port        int
-	Router      http.Handler
+	CertPool       *x509.CertPool
+	BindAddress    string
+	Port           int
+	Router         http.Handler
+	TLSCompatLevel TLSConfigCompatLevel
 }
 
 // NewTLSServer sets up a Pantheon(TM) type of tls server that Requires and Verifies peer cert
 func NewTLSServer(config TLSServerConfig) *http.Server {
+	// Setup our TLS config
+	tlsConfig := NewTLSConfig(config.TLSCompatLevel)
+	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
+	tlsConfig.ClientCAs = config.CertPool
+
 	// Setup client authentication
 	server := &http.Server{
-		TLSConfig: &tls.Config{
-			ClientAuth: tls.RequireAndVerifyClientCert,
-			ClientCAs:  config.CertPool,
-		},
-		Addr:    fmt.Sprintf("%s:%d", config.BindAddress, config.Port),
-		Handler: config.Router,
+		TLSConfig: tlsConfig,
+		Addr:      fmt.Sprintf("%s:%d", config.BindAddress, config.Port),
+		Handler:   config.Router,
 	}
 	server.TLSConfig.BuildNameToCertificate()
 	return server

--- a/certutils/certutils_pre_go18.go
+++ b/certutils/certutils_pre_go18.go
@@ -1,4 +1,4 @@
-// +build go1.8
+// +build !go1.8
 
 package certutils
 
@@ -40,7 +40,6 @@ func NewTLSConfig(level TLSConfigLevel) *tls.Config {
 		// Only use curves which have assembly implementations
 		c.CurvePreferences = []tls.CurveID{
 			tls.CurveP256,
-			tls.X25519,
 		}
 	case TLSConfigModern:
 		// Modern compat sets TLS_1.2 minimum version and a set of ciphers that support PFS
@@ -48,8 +47,6 @@ func NewTLSConfig(level TLSConfigLevel) *tls.Config {
 		c.CipherSuites = []uint16{
 			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
-			tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 		}
@@ -77,13 +74,11 @@ func NewTLSServer(config TLSServerConfig) *http.Server {
 
 	// Setup client authentication
 	server := &http.Server{
-		ReadHeaderTimeout: 5 * time.Second, // Go 1.8 only
-		ReadTimeout:       5 * time.Second,
-		WriteTimeout:      10 * time.Second,
-		IdleTimeout:       120 * time.Second, // Go 1.8 only
-		TLSConfig:         tlsConfig,
-		Addr:              fmt.Sprintf("%s:%d", config.BindAddress, config.Port),
-		Handler:           config.Router,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		TLSConfig:    tlsConfig,
+		Addr:         fmt.Sprintf("%s:%d", config.BindAddress, config.Port),
+		Handler:      config.Router,
 	}
 	server.TLSConfig.BuildNameToCertificate()
 	return server


### PR DESCRIPTION
Based on:
https://blog.gopheracademy.com/advent-2016/exposing-go-on-the-internet/
provide a NewTLSConfig() function for acquiring a tls.Config struct
that is pre-populated with best practice TLS settings.

addresses feature req #7 