### PR TITLE
add certutils.CertReloader

### DIFF
--- a/certutils/reloader.go
+++ b/certutils/reloader.go
@@ -1,0 +1,124 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This code is based on the example in https://github.com/kelseyhightower/kube-cert-manager/blob/master/tls-app/certificate-manager.go
+
+package certutils
+
+import (
+	"crypto/tls"
+	"sync"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// CertReloader provides a mechanism for reloading a TLS key and cert upon file change
+type CertReloader struct {
+	sync.RWMutex
+	certificate *tls.Certificate
+	certFile    string
+	keyFile     string
+	Error       chan error
+	watcher     *fsnotify.Watcher
+}
+
+// NewCertReloader returns a new CertReloader
+func NewCertReloader(certFile, keyFile string) (*CertReloader, error) {
+	cr := &CertReloader{
+		certFile: certFile,
+		keyFile:  keyFile,
+		Error:    make(chan error, 10),
+	}
+	err := cr.setCertificate()
+	if err != nil {
+		return nil, err
+	}
+
+	go cr.watchCertificate()
+
+	return cr, nil
+}
+
+// GetCertificate implements the tls.Config GetCertificate() func
+func (cr *CertReloader) GetCertificate(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	cr.RLock()
+	defer cr.RUnlock()
+	return cr.certificate, nil
+}
+
+// GetCertificate implements the tls.Config GetClientCertificate() func
+func (cr *CertReloader) GetClientCertificate(req *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	cr.RLock()
+	defer cr.RUnlock()
+	return cr.certificate, nil
+}
+
+// TLSConfigApplyReloader patches a *tls.Config struct by setting the GetCertificate and GetClientCertificate
+// methods.
+func (cr *CertReloader) TLSConfigApplyReloader(cfg *tls.Config) {
+	cfg.GetCertificate = cr.GetCertificate
+	cfg.GetClientCertificate = cr.GetClientCertificate
+}
+
+func (cr *CertReloader) setCertificate() error {
+	c, err := tls.LoadX509KeyPair(cr.certFile, cr.keyFile)
+	if err != nil {
+		return err
+	}
+	cr.Lock()
+	cr.certificate = &c
+	cr.Unlock()
+	return nil
+}
+
+func (cr *CertReloader) watchCertificate() error {
+	err := cr.newWatcher()
+	if err != nil {
+		return err
+	}
+
+	for {
+		select {
+		case <-cr.watcher.Events:
+			err := cr.setCertificate()
+			if err != nil {
+				cr.Error <- err
+			}
+			err = cr.resetWatcher()
+			if err != nil {
+				cr.Error <- err
+			}
+		case err := <-cr.watcher.Errors:
+			cr.Error <- err
+		}
+	}
+}
+
+func (cr *CertReloader) newWatcher() error {
+	var err error
+	cr.watcher, err = fsnotify.NewWatcher()
+	if err != nil {
+		return err
+	}
+	err = cr.watcher.Add(cr.certFile)
+	if err != nil {
+		return err
+	}
+	return cr.watcher.Add(cr.keyFile)
+}
+
+func (cr *CertReloader) resetWatcher() error {
+	err := cr.watcher.Close()
+	if err != nil {
+		return err
+	}
+	return cr.newWatcher()
+}

--- a/examples/cert_reloader/main.go
+++ b/examples/cert_reloader/main.go
@@ -1,0 +1,67 @@
+package main
+
+/*
+Example usage of the certutils.CertReloader providing on the fly cert reloads
+
+	$ go run main.go &
+
+	$ curl https://localhost:18080/
+	hello, world!
+
+	$ touch ../test-fixtures/server.pem
+	2017/09/04 07:28:35 Reloading TLS certificates...
+  2017/09/04 07:28:35 Loading TLS certificates...
+  2017/09/04 07:28:35 Reloading TLS certificates complete.
+*/
+
+import (
+	"crypto/tls"
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/pantheon-systems/go-certauth/certutils"
+)
+
+func HelloServer(w http.ResponseWriter, req *http.Request) {
+	io.WriteString(w, "hello, world!\n")
+}
+
+func main() {
+	router := http.HandlerFunc(HelloServer)
+
+	// load CA cert. (NOTE: on the fly reloading of CA certs is not currently supported)
+	caCerts, err := certutils.LoadCACertFile("../test-fixtures/ca.crt")
+	if err != nil {
+		log.Fatalf("Unable to load ca.crt: %s", err)
+	}
+
+	// setup a cert reloader using our TLS key and cert
+	reloader, err := certutils.NewCertReloader("../test-fixtures/server.pem", "../test-fixtures/server.pem")
+	if err != nil {
+		log.Fatalf("Unable to load TLSkey+cert: %s", err)
+	}
+
+	// create a TLS server
+	cfg := certutils.TLSServerConfig{
+		CertPool:    caCerts,
+		BindAddress: "",
+		Port:        18080,
+		Router:      router,
+	}
+	server := certutils.NewTLSServer(cfg)
+	server.TLSConfig.ClientAuth = tls.NoClientCert // Disable client cert requirement for this example
+
+	// Modify the server's TLSConfig (*tls.Config) to support on the fly cert reloading
+	reloader.TLSConfigApplyReloader(server.TLSConfig)
+	// Handle any errors from the cert reloader. An app may choose to cleanup
+	// and shutdown at this point. Or, just log any errors and keep running.
+	// The cert loaded at startup will continue to be used, although it may be expired.
+	go func() {
+		for e := range reloader.Error {
+			log.Printf("Error from cert reloader: %s", e)
+		}
+	}()
+
+	log.Fatal(server.ListenAndServeTLS("", ""))
+}


### PR DESCRIPTION
CertReloader provides a background go-routine that will automatically
reload TLS key+cert files when they're changed on disk. It implements the
GetCertificate() and GetClientCertificate() funcs used by tls.Config to
dynamically load key+cert data as needed.

Example provided as usage/documentation.