### PR TITLE
Certinel Compatability

### DIFF
--- a/certutils/certutils.go
+++ b/certutils/certutils.go
@@ -64,6 +64,7 @@ type TLSServerConfig struct {
 	Port           int
 	Router         http.Handler
 	TLSConfigLevel TLSConfigLevel
+	GetCertificate func(*tls.ClientHelloInfo) (*tls.Certificate, error)
 }
 
 // NewTLSServer sets up a Pantheon(TM) type of tls server that Requires and Verifies peer cert
@@ -74,6 +75,10 @@ func NewTLSServer(config TLSServerConfig) *http.Server {
 	// By default this server will require client MTLS certs and verify cert validity against the config.CertPool CA bundle
 	tlsConfig.ClientAuth = tls.RequireAndVerifyClientCert
 	tlsConfig.ClientCAs = config.CertPool
+
+	if config.GetCertificate != nil {
+		tlsConfig.GetCertificate = config.GetCertificate
+	}
 
 	// Setup client authentication
 	server := &http.Server{


### PR DESCRIPTION
adding ability to pass in GetCertificate method to TLS config for Certinel

Usage:
```
watcher := pollwatcher.New(tlsCertPath, tlsKeyPath, 5*time.Minute)
sentinel := certinel.New(watcher, nil, func(err error) {
    log.Fatalf("error: certinel was unable to reload the certificate. err='%s'", err)
})

sentinel.Watch()

caCerts, err := certutils.LoadCACertFile(caCertPath)
if err != nil {
    logrus.WithError(err).Fatal("unable to load CA cert")
}

auth := certauth.NewAuth(certauth.Options{
    AllowedOUs: []string{"titan"},
})

router := auth.Handler(http.HandlerFunc(func ....))

cfg := certutils.TLSServerConfig{
    CertPool:         caCerts,
    BindAddress:  "",
    Port:                1234,
    Router:            router,
   GetCertificate: sentinel.GetCertificate,
}

server := certutils.NewTLSServer(cfg)

server.ListenAndServeTLS("","")
```

where the sentinel object is created with the library
https://github.com/pantheon-systems/certinel