### PR TITLE
Refactored Authorization into an interface

### DIFF
--- a/authorization.go
+++ b/authorization.go
@@ -1,0 +1,117 @@
+package certauth
+
+import (
+	"fmt"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+// ContextKey and ContextValue are type aliases to make the code a bit more readable.
+type ContextKey interface{}
+type ContextValue interface{}
+
+// AuthorizationChecker provides an interface for checking request authorization programatically.
+// The CheckAuthorization* methods will be called upon a request to verify that the provided client
+// is authorized to access the requested resource.
+// If authorization is allowed, the AuthorizationChecker should return a nil error value.
+// If authorization is denied, the AuthorizationChecker should return an error value with some
+// description of why the request is being denied.
+// If the request is allowed, the AuthorizationChecker may return a map of key/value pairs.
+// These key/value pairs are added to the request's context using `context.WithValue` by the
+// middleware. Downstream applications can then use these values if desired.
+// See the methods for a description of which Allow* method is chosen depending on the
+// request.
+type AuthorizationChecker interface {
+	// CheckAuthorization is called for requests which do not use the `httprouter` framework.
+	// `clientOU` and `clientCN` are set to the values determined from the x509 client certificate.
+	CheckAuthorization(clientOU []string, clientCN string) (map[ContextKey]ContextValue, error)
+
+	// CheckAuthorizationWithParams is called for requests which use the `httprouter` framework.
+	// This allows the authorization behavior to respond to the resource that's being requested.
+	CheckAuthorizationWithParams(
+		clientOU []string, clientCN string, ps httprouter.Params,
+	) (map[ContextKey]ContextValue, error)
+}
+
+// AllowOUsandCNs is a convenience function which produces an AuthorizationChecker from a list
+// of allowed OUs and CNs. Requests are allowed if one of their OUs is contained in `allowedOUs`
+// and their CN is contained in `allowedCNs`.
+// Either of `allowedOUs` or `allowedCNs` is permitted to be nil, which disables checking that
+// field.
+func AllowOUsandCNs(allowedOUs, allowedCNs []string) AuthorizationChecker {
+	return AllowSpecificOUandCNs{OUs: allowedOUs, CNs: allowedCNs}
+}
+
+// AllowSpecificOUandCNs is an AuthorizationChecker which allows access to
+// resources for the specific Organizational Units and common names.
+// If any of the client's OUs match (i.e. `==`) any of the server's allowed OUs, *and*
+// the client's CN matches (i.e. `==`) one of the server's allowed CNs, the request
+// is allowed.
+// If `OUs` is empty or nil, the client's OU is ignored, and only the CN is used to determine
+// authorization.
+// If `CNs` is empty or nil, the client's CN is ignored, and only the OU is used to determine
+// authorization.
+// If both `OUs` and `CNs` are empty or nil, all requests are allowed.
+// Site resources are not considered specially. CheckAuthorizationWithParams has exactly the same
+// behavior as CheckAuthorization (i.e. the parameters are ignored).
+type AllowSpecificOUandCNs struct {
+	OUs []string
+	CNs []string
+}
+
+func (allow AllowSpecificOUandCNs) CheckAuthorization(
+	clientOU []string, clientCN string,
+) (map[ContextKey]ContextValue, error) {
+	results := make(map[ContextKey]ContextValue)
+
+	if allow.OUs != nil && len(allow.OUs) > 0 {
+		if err := allowedOU(allow.OUs, clientOU); err != nil {
+			return nil, err
+		}
+		results[HasAuthorizedOU] = clientOU
+	}
+	if allow.CNs != nil && len(allow.CNs) > 0 {
+		if err := allowedCN(allow.CNs, clientCN); err != nil {
+			return nil, err
+		}
+		results[HasAuthorizedCN] = clientCN
+	}
+	return results, nil
+}
+
+func (allow AllowSpecificOUandCNs) CheckAuthorizationWithParams(
+	clientOU []string, clientCN string, ps httprouter.Params,
+) (map[ContextKey]ContextValue, error) {
+	// URI parameters are not handled separately. Fall back to the behavior
+	// of CheckAuthorization
+	return allow.CheckAuthorization(clientOU, clientCN)
+}
+
+//
+// Unexported helper functions below
+//
+
+func allowedCN(allowedCNs []string, clientCN string) error {
+	for _, cn := range allowedCNs {
+		if cn == clientCN {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"cert failed CN validation for %v, Allowed: %v", clientCN, allowedCNs)
+}
+
+func allowedOU(allowedOUs []string, clientOUs []string) error {
+	var failed []string
+
+	for _, ou := range allowedOUs {
+		for _, clientOU := range clientOUs {
+			if ou == clientOU {
+				return nil
+			}
+			failed = append(failed, clientOU)
+		}
+	}
+	return fmt.Errorf(
+		"cert failed OU validation for %v, Allowed: %v", failed, allowedOUs)
+}

--- a/authorization_test.go
+++ b/authorization_test.go
@@ -1,0 +1,121 @@
+package certauth_test
+
+import (
+	"testing"
+
+	. "github.com/pantheon-systems/go-certauth"
+)
+
+func TestAuthValidateOU(t *testing.T) {
+	// Tests that OU validation works as expected
+	tests := []struct {
+		AllowedOUs []string
+		ActualOUs  []string
+		IsAllowed  bool
+	}{
+		{[]string{}, []string{"endpoint"}, true},
+		{[]string{"endpoint"}, []string{"endpoint"}, true},
+		{[]string{"endpoint"}, []string{"site"}, false},
+		{[]string{"endpoint"}, []string{""}, false},
+		{[]string{"endpoint", "titan"}, []string{"site"}, false},
+		{[]string{"endpoint", "titan"}, []string{"titan"}, true},
+	}
+
+	for _, tc := range tests {
+		check := AllowSpecificOUandCNs{OUs: tc.AllowedOUs, CNs: nil}
+		_, err := check.CheckAuthorization(tc.ActualOUs, "")
+
+		if err != nil && tc.IsAllowed {
+			t.Errorf(
+				"Expected AllowedOUs (%v) and ActualOUs (%v) "+
+					"to pass validation, but it failed: err: %s",
+				tc.AllowedOUs, tc.ActualOUs, err,
+			)
+		}
+
+		if err == nil && !tc.IsAllowed {
+			t.Errorf(
+				"Expected AllowedOUs (%v) and ActualOUs (%v) "+
+					"to fail validation, but it passed.",
+				tc.AllowedOUs, tc.ActualOUs,
+			)
+		}
+	}
+}
+
+func TestAuthValidateCN(t *testing.T) {
+	// Tests that CN validation works as expected
+	tests := []struct {
+		AllowedCNs []string
+		ActualCN   string
+		IsAllowed  bool
+	}{
+		{[]string{}, "site1", true},
+		{[]string{"site1"}, "site1", true},
+		{[]string{"site1"}, "site", false},
+		{[]string{"site1"}, "", false},
+		{[]string{"site1", "site2"}, "site1", true},
+		{[]string{"site1", "site2"}, "site2", true},
+		{[]string{"site1", "site2"}, "site3", false},
+	}
+
+	for _, tc := range tests {
+		check := AllowSpecificOUandCNs{OUs: nil, CNs: tc.AllowedCNs}
+		_, err := check.CheckAuthorization([]string{""}, tc.ActualCN)
+
+		if err != nil && tc.IsAllowed {
+			t.Errorf(
+				"Expected AllowedCNs (%v) and ActualCN (%v) "+
+					"to pass validation, but it failed: err: %s",
+				tc.AllowedCNs, tc.ActualCN, err,
+			)
+		}
+
+		if err == nil && !tc.IsAllowed {
+			t.Errorf(
+				"Expected AllowedCNs (%v) and ActualCN (%v) "+
+					"to fail validation, but it passed.",
+				tc.AllowedCNs, tc.ActualCN,
+			)
+		}
+	}
+}
+
+func TestAuthWithParams(t *testing.T) {
+	// Tests that HasAuthorizedOU and HasAuthorizedCN are in the response
+	actualCN := "i_am_a_cn"
+	actualOU := "i_am_an_ou"
+
+	check := AllowSpecificOUandCNs{OUs: nil, CNs: []string{actualCN}}
+	params, err := check.CheckAuthorization([]string{actualOU}, actualCN)
+
+	if err != nil {
+		t.Errorf(
+			"Expected AllowedCNs (%v) and ActualCN (%v) to pass validation, but it failed: err: %s",
+			check.CNs, actualCN, err,
+		)
+	}
+	v, ok := params[HasAuthorizedCN]
+	if !ok {
+		t.Errorf("Expected context key %q was not present %v", HasAuthorizedCN.String(), params)
+	} else if v != actualCN {
+		t.Errorf("Expected context value %q but received %q", actualCN, v)
+	}
+
+	check = AllowSpecificOUandCNs{OUs: []string{actualOU}, CNs: nil}
+	params, err = check.CheckAuthorization([]string{actualOU}, actualCN)
+
+	if err != nil {
+		t.Errorf(
+			"Expected AllowedOUs (%v) and ActualOU (%v) to pass validation, but it failed: err: %s",
+			check.OUs, actualOU, err,
+		)
+	}
+	v, ok = params[HasAuthorizedOU]
+	vl := v.([]string)
+	if !ok {
+		t.Errorf("Expected context key %q was not present %v", HasAuthorizedOU.String(), params)
+	} else if len(vl) != 1 || vl[0] != actualOU {
+		t.Errorf("Expected context value %q but received %q", actualOU, v)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/pantheon-systems/go-certauth
 
 go 1.16
 
-require github.com/julienschmidt/httprouter v1.3.1-0.20200921135023-fe77dd05ab5a
+require (
+	github.com/google/uuid v1.2.0
+	github.com/julienschmidt/httprouter v1.3.1-0.20200921135023-fe77dd05ab5a
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/julienschmidt/httprouter v1.3.1-0.20200921135023-fe77dd05ab5a h1:VTF3sHLbpm2PdWMPKVWUMwKg85VE7Ep7wgBw8ETYri8=
 github.com/julienschmidt/httprouter v1.3.1-0.20200921135023-fe77dd05ab5a/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=


### PR DESCRIPTION
This PR adds new authorization code to the certauth middleware with a few improvements:

- Authorization has been generalized into an interface: `AuthorizationChecker`
  Multiple `AuthorizationChecker`s can be provided in the `certauth.Options` struct and they must all pass for a request to be allowed.
  This obsoletes the `AllowedOUs` and `AllowedCNs` fields on the `certauth.Options` struct.
- `AuthorizationChecker` may return arbitrary key/value pairs which are merged into the request's `context` (if Authorization is allowed) before running the application's handler.

For now this is only the interface (and backward compatibility for `AllowedOUs` and `AllowedCNs`). The Pantheon site authorization code is going to go into a separate PR which I am still working on.

EDIT: I updated this to reflect the latest state of the PR as the original goal of this PR has changed since I first wrote this summary.