### PR TITLE
Added pantheon package for pantheon-specific site authorization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,7 @@ jobs:
       - checkout
       - restore-go-mod-cache
       - save-build-num
-      # FIXME: this project does not have a makefile!
-      - run: go test
-      - run: go build
+      - run: make
       - save-go-mod-cache
       - save-workspace
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+PROJECT_PATH = github.com/pantheon-systems/go-certauth
+
+
+.PHONY: all
+all: test build
+
+
+.PHONY: test
+test:
+	go test $(PROJECT_PATH)
+	go test $(PROJECT_PATH)/pantheon
+
+
+.PHONY: build
+build:
+	go build $(PROJECT_PATH)
+	go build $(PROJECT_PATH)/pantheon

--- a/pantheon/pantheon_auth.go
+++ b/pantheon/pantheon_auth.go
@@ -1,0 +1,160 @@
+package pantheon_auth
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/pantheon-systems/go-certauth"
+)
+
+// These shenanigans are here to ensure we have strings on our context keys, and they are unique to our package
+type contextKey string
+
+func (c contextKey) String() string {
+	return "pantheon context " + string(c)
+}
+
+const (
+	// PantheonSite is used as the request context key identifying the client's Site (if present)
+	PantheonSite = contextKey("Pantheon Site")
+
+	//PantheonEnv is used as the request context key identifying the client's environment
+	// (if present)
+	PantheonEnv = contextKey("Pantheon Env")
+)
+
+// Helper function which produces AuthorizationCheckers suitable for use in Pantheon HTTP servers.
+// This function accepts three lists which determine which clients pass authorization checks
+// and produces 2 AuthorizationCheckers to implement these checks.
+// `allowedOUs` and `allowedCNs` determine which clients will be allowed to pass authorization
+// checks. Clients with an OU within `siteOUs` will be subject to an additional check for valid
+// site authorization. See below for a description of how site authorization works.
+// Requests are allowed if they pass `allowedOUs`, `allowedCNs` *and* site authorization
+// (if applicable). Note that this means `siteOUs` should be a subset of `allowedOUs` otherwise
+// site authorization checks will always fail.
+// See also the documentation for AllowSpecificOUandCNs for more details on the behavior or
+// `allowedOUs` and `allowedCNs`.
+//
+// Site authorization checks are intended to protect resources belonging to one site (i.e. with a
+// `site` URI parameter) from being accessed by requests from other sites.
+// For example: if site A makes a request for information belonging to site B, that request should
+// fail the site authorization check.
+//
+// The way this works hinges on the use of URI parameters with the `httprouter` framework.
+// Essentially, the server can define certain URIs as being site-specific by adding a `site` URI
+// parameter. The site authorization check then compares the `site` URI parameter with the `site`
+// determined from the client certificate's CommonName. If they match, then the request is allowed.
+//
+// However, this check should only be run for some clients, particularly client's that have
+// authenticated as a site (rather than, for example, a backend service). To conditionally apply
+// this check, the `siteOUs` parameter allows you to specify which Organizational Units this site
+// authorization check should be run for.
+//
+// In order for site authorization checks to be run, a few things must be true:
+// 1. The server must be using the `httprouter` framework.
+// 2. The server must define the `site` URI parameter in the URI path.
+// 3. The request must be performed against one of the URIs with the `site` parameter.
+// 4. At least one of the request's OUs must be present in the `siteOUs` option of `PantheonSiteAuth`
+// If all of these conditions are true, then an additional check is performed.
+// The workflow for this check is:
+// 1. Parse the request x509's CommonName to obtain the site ID.
+// 2. Obtain the site ID from the URI parameters.
+// 3. Ensure the site ID from the CommonName and site ID from the URI parameters match.
+func PantheonSiteAuth(allowedOUs, allowedCNs, siteOUs []string) []certauth.AuthorizationChecker {
+	return []certauth.AuthorizationChecker{
+		certauth.AllowOUsandCNs(allowedOUs, allowedCNs),
+		PantheonSiteAuthChecker{siteOUs},
+	}
+}
+
+// PantheonSiteAuth is an instance of AuthorizationChecker which performs pantheon-specific
+// site authorization checks. See documentation for PantheonSiteAuth for details.
+type PantheonSiteAuthChecker struct {
+	SiteOUs []string
+}
+
+func (check PantheonSiteAuthChecker) CheckAuthorization(
+	clientOU []string, clientCN string,
+) (map[certauth.ContextKey]certauth.ContextValue, error) {
+	// Site authorization does not apply to this request because the server
+	// is not using the `httprouter` framework.
+
+	// TODO(zeal): Maybe fail here since we expect all pantheon HTTP servers to be using
+	//             `httprouter`?
+	return nil, nil
+}
+
+func (check PantheonSiteAuthChecker) CheckAuthorizationWithParams(
+	clientOU []string, clientCN string, ps httprouter.Params,
+) (map[certauth.ContextKey]certauth.ContextValue, error) {
+	if !checkOUMembership(check.SiteOUs, clientOU) {
+		// Site authorization does not apply to this request because
+		// the request is not a member of any of the SiteOUs.
+		return nil, nil
+	}
+	uriSite := ps.ByName("site")
+	if uriSite == "" {
+		// Site authorization does not apply to this request because
+		// the request is not for a resource with the `site` URI parameter.
+		return nil, nil
+	}
+
+	// From here on, we *know* we need to check this request's authorization.
+
+	certSite, certEnv, err := ParseSiteEnvFromCN(clientCN)
+	if err != nil {
+		// Couldn't parse site/env from CN, so reject the request...
+		return nil, err
+	}
+
+	if certSite != uriSite {
+		return nil, fmt.Errorf(
+			"site %q is not authorized to requests for site %q",
+			certSite,
+			uriSite,
+		)
+	}
+
+	return prepareSiteContextParams(certSite, certEnv), nil
+}
+
+func prepareSiteContextParams(site, env string) map[certauth.ContextKey]certauth.ContextValue {
+	return map[certauth.ContextKey]certauth.ContextValue{
+		certauth.ContextKey(PantheonSite): certauth.ContextValue(site),
+		certauth.ContextKey(PantheonEnv):  certauth.ContextValue(env),
+	}
+}
+
+// Checks a client's list of OUs against the server's list of OUs and returns true if there
+// are any in common.
+func checkOUMembership(serverOUs, clientOUs []string) bool {
+	for _, sou := range serverOUs {
+		for _, cou := range clientOUs {
+			if sou == cou {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ParseSiteEnvFromCN parses a site id and environment from the provided CN.
+// Also validates that the site ID is a valid UUID.
+// Returns (site, environment, nil) if the clientCN is valid.
+// Returns ("", "", err) if an error occurs.
+func ParseSiteEnvFromCN(clientCN string) (string, string, error) {
+	// Site CN in format of env.site_uuid.domain
+	words := strings.SplitN(clientCN, ".", 3)
+
+	if len(words) != 3 {
+		return "", "", fmt.Errorf("unexpected CN format: %q", clientCN)
+	}
+	_, err := uuid.Parse(words[1])
+	if err != nil {
+		return "", "", fmt.Errorf("site ID (from CN) is not a valid UUID: %q", words[1])
+	}
+	return words[1], words[0], nil
+}

--- a/pantheon/pantheon_auth_test.go
+++ b/pantheon/pantheon_auth_test.go
@@ -1,0 +1,245 @@
+package pantheon_auth_test
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/pantheon-systems/go-certauth"
+	pantheon_auth "github.com/pantheon-systems/go-certauth/pantheon"
+)
+
+func expect(t *testing.T, actual interface{}, expected interface{}) {
+	t.Helper()
+	if actual != expected {
+		t.Errorf("Expected [%v] (type %T) - Got [%v] (type %T)", expected, expected, actual, actual)
+	}
+}
+
+func expectErr(t *testing.T, actual error, expected error) {
+	t.Helper()
+	if (actual == nil && expected == nil) || (actual != nil && expected != nil && actual.Error() == expected.Error()) {
+		return
+	}
+	t.Errorf("Expected error [%v] - Got error [%v]", expected, actual)
+}
+
+type fakeCertData struct {
+	ou []string
+	cn string
+}
+
+// fakeCertChain will turn a []fakeCertData into a [][]*x509.Certificate which is the
+// type found in the `http.Request.TLS.VerifiedChains` attribute.
+func fakeCertChain(certChainData ...fakeCertData) [][]*x509.Certificate {
+	chain := []*x509.Certificate{}
+	for _, certData := range certChainData {
+		cert := &x509.Certificate{
+			Subject: pkix.Name{
+				OrganizationalUnit: []string(certData.ou),
+				CommonName:         string(certData.cn),
+			},
+		}
+		chain = append(chain, cert)
+	}
+	return [][]*x509.Certificate{chain}
+}
+
+// helper function to create a single test certificate with one OU and the given CN
+func makeFakeCert(ou, cn string) [][]*x509.Certificate {
+	return fakeCertChain(
+		fakeCertData{[]string{ou}, cn},
+	)
+}
+
+func TestSiteAuthorization(t *testing.T) {
+	// This test sets up a httprouter server with an endpoint specifically made to test site
+	// authorization.
+	auth := certauth.NewAuth(certauth.Options{
+		AuthorizationCheckers: pantheon_auth.PantheonSiteAuth(
+			// Only allow OUs `site` and `engineering`
+			[]string{"site", "engineering"},
+			// No restrictions on CNs
+			nil,
+			// If the OU is `site` do a site-authorization check
+			[]string{"site"},
+		),
+	})
+
+	siteResource := "/site_test/:site"
+	nonSiteResource := "/not_site_test/:nosite"
+
+	rtr := httprouter.New()
+	// If authorization passes, the handler fetches the URI's site and
+	// certificate's site and writes them back to the client via the http
+	// response body so the test can assert on the content.
+	rtr.GET(siteResource, auth.RouterHandler(httprouter.Handle(
+		func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+			uriSite := ps.ByName("site")
+			certSite, ok := r.Context().Value(pantheon_auth.PantheonSite).(string)
+			if !ok {
+				certSite = "<none>"
+			}
+			fmt.Fprintf(w, "%s,%s", certSite, uriSite)
+		},
+	)))
+	// This resource does not run site authorization checks because it's URI
+	// parameter is not `site`
+	rtr.GET(nonSiteResource, auth.RouterHandler(httprouter.Handle(
+		func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+			uriSite := ps.ByName("nosite")
+			certSite, ok := r.Context().Value(pantheon_auth.PantheonSite).(string)
+			if !ok {
+				certSite = "<none>"
+			}
+			fmt.Fprintf(w, "%s,%s", certSite, uriSite)
+		},
+	)))
+
+	site1 := "00c66762-d8ac-450b-b368-459c5d4f6aab"
+	site1url := "https://foo.bar" + strings.ReplaceAll(siteResource, ":site", site1)
+	nsite1url := "https://foo.bar" + strings.ReplaceAll(nonSiteResource, ":nosite", site1)
+	site2 := "1fab8f7f-b5cc-411d-abed-7432dd62af60"
+	site2url := "https://foo.bar" + strings.ReplaceAll(siteResource, ":site", site2)
+	nsite2url := "https://foo.bar" + strings.ReplaceAll(nonSiteResource, ":nosite", site2)
+
+	// slices cannot be key indices, so we create this lookup table so we can use a string
+	// as the key index in `tests` below and lookup the cert for that test case later.
+	clientCerts := map[string][][]*x509.Certificate{
+		"admin": makeFakeCert("engineering", "admin@foo.com"),
+		"site1": makeFakeCert("site", fmt.Sprintf("dev.%s.foo.com", site1)),
+		"site2": makeFakeCert("site", fmt.Sprintf("dev.%s.foo.com", site2)),
+	}
+
+	type expectedResponse struct {
+		expCode int
+		expBody string
+	}
+
+	// This is a map from clients to urls to expected responses...
+	// If this client sends a request to this URL, what should the response be?
+	testCases := map[string]map[string]expectedResponse{
+		// admin can send responses to every url
+		// and should have a cert site of `<none>` (see handler above)
+		"admin": {
+			site1url: {
+				expCode: http.StatusOK,
+				expBody: fmt.Sprintf("<none>,%s", site1),
+			},
+			site2url: {
+				expCode: http.StatusOK,
+				expBody: fmt.Sprintf("<none>,%s", site2),
+			},
+			nsite1url: {
+				expCode: http.StatusOK,
+				expBody: fmt.Sprintf("<none>,%s", site1),
+			},
+			nsite2url: {
+				expCode: http.StatusOK,
+				expBody: fmt.Sprintf("<none>,%s", site2),
+			},
+		},
+		"site1": {
+			site1url: {
+				expCode: http.StatusOK,
+				expBody: fmt.Sprintf("%s,%s", site1, site1),
+			},
+			site2url: {
+				expCode: http.StatusForbidden,
+				expBody: "Authentication Failed",
+			},
+			nsite1url: {
+				expCode: http.StatusOK,
+				expBody: fmt.Sprintf("<none>,%s", site1),
+			},
+			nsite2url: {
+				expCode: http.StatusOK,
+				expBody: fmt.Sprintf("<none>,%s", site2),
+			},
+		},
+		"site2": {
+			site1url: {
+				expCode: http.StatusForbidden,
+				expBody: "Authentication Failed",
+			},
+			site2url: {
+				expCode: http.StatusOK,
+				expBody: fmt.Sprintf("%s,%s", site2, site2),
+			},
+			nsite1url: {
+				expCode: http.StatusOK,
+				expBody: fmt.Sprintf("<none>,%s", site1),
+			},
+			nsite2url: {
+				expCode: http.StatusOK,
+				expBody: fmt.Sprintf("<none>,%s", site2),
+			},
+		},
+	}
+	for clientName, ctc := range testCases {
+		cert := clientCerts[clientName]
+		for url, tc := range ctc {
+			t.Run(fmt.Sprintf("%s=>%s", clientName, url), func(t2 *testing.T) {
+				w := httptest.NewRecorder()
+				req, _ := http.NewRequest("GET", url, nil)
+				req.TLS = &tls.ConnectionState{}
+				req.TLS.VerifiedChains = cert
+
+				rtr.ServeHTTP(w, req)
+				expect(t2, w.Code, tc.expCode)
+				expect(t2, strings.TrimSpace(w.Body.String()), strings.TrimSpace(tc.expBody))
+			})
+		}
+	}
+
+}
+
+func TestParsesCNProperly(t *testing.T) {
+	tests := []struct {
+		InputCN      string
+		ExpectedSite string
+		ExpectedEnv  string
+		ExpectedErr  error
+	}{
+		{
+			"dev.de7ad059-19dd-4e45-9095-ef7507d8195b.pantheon.com",
+			"de7ad059-19dd-4e45-9095-ef7507d8195b",
+			"dev",
+			nil,
+		},
+		{
+			"foobar.9eb5ca28-09be-45b9-8068-7ed6af62fcad.some.website.edu",
+			"9eb5ca28-09be-45b9-8068-7ed6af62fcad",
+			"foobar",
+			nil,
+		},
+		{
+			"I_AM_A_CN",
+			"",
+			"",
+			fmt.Errorf(`unexpected CN format: "I_AM_A_CN"`),
+		},
+		{
+			"dev.myspecialsite1.pantheon.com",
+			"",
+			"",
+			fmt.Errorf(`site ID (from CN) is not a valid UUID: "myspecialsite1"`),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("CN %s", tc.InputCN), func(t2 *testing.T) {
+			actualSite, actualEnv, actualErr := pantheon_auth.ParseSiteEnvFromCN(tc.InputCN)
+
+			expectErr(t2, actualErr, tc.ExpectedErr)
+			expect(t2, actualSite, tc.ExpectedSite)
+			expect(t2, actualEnv, tc.ExpectedEnv)
+		})
+	}
+}


### PR DESCRIPTION
Depends on: #13 

Use the `AuthorizationChecker` interface introduced in #13 to introduce an `AuthorizationChecker` which performs pantheon site authorization.

See the comment above `PantheonSiteAuth` for details, but TLDR:
> Site authorization checks are intended to protect resources belonging to one site (i.e. with a
> site` URI parameter) from being accessed by requests from other sites.
> For example: if site A makes a request for information belonging to site B, that request should
> fail the site authorization check.

I feel like the unit tests for this are fairly solid, but if you can think of any cases I missed, I'd be happy to add more.

I also added a simple makefile since the project now has 2 go packages that should both be tested in CI.