### PR TITLE
Minor changes to pantheon site authentication flow

### DIFF
--- a/authorization.go
+++ b/authorization.go
@@ -98,20 +98,17 @@ func allowedCN(allowedCNs []string, clientCN string) error {
 		}
 	}
 	return fmt.Errorf(
-		"cert failed CN validation for %v, Allowed: %v", clientCN, allowedCNs)
+		"cert failed CN validation for %q, allowed: %v", clientCN, allowedCNs)
 }
 
 func allowedOU(allowedOUs []string, clientOUs []string) error {
-	var failed []string
-
 	for _, ou := range allowedOUs {
 		for _, clientOU := range clientOUs {
 			if ou == clientOU {
 				return nil
 			}
-			failed = append(failed, clientOU)
 		}
 	}
 	return fmt.Errorf(
-		"cert failed OU validation for %v, Allowed: %v", failed, allowedOUs)
+		"cert failed OU validation for %v, allowed: %v", clientOUs, allowedOUs)
 }

--- a/authorization_test.go
+++ b/authorization_test.go
@@ -3,119 +3,110 @@ package certauth_test
 import (
 	"testing"
 
-	. "github.com/pantheon-systems/go-certauth"
+	"github.com/pantheon-systems/go-certauth"
 )
 
 func TestAuthValidateOU(t *testing.T) {
 	// Tests that OU validation works as expected
-	tests := []struct {
-		AllowedOUs []string
-		ActualOUs  []string
-		IsAllowed  bool
+	testCases := []struct {
+		Name        string
+		AllowedOUs  []string
+		ActualOUs   []string
+		ExpectedErr error
 	}{
-		{[]string{}, []string{"endpoint"}, true},
-		{[]string{"endpoint"}, []string{"endpoint"}, true},
-		{[]string{"endpoint"}, []string{"site"}, false},
-		{[]string{"endpoint"}, []string{""}, false},
-		{[]string{"endpoint", "titan"}, []string{"site"}, false},
-		{[]string{"endpoint", "titan"}, []string{"titan"}, true},
+		{"NilServerOU", nil, []string{"endpoint"}, nil},
+		{"EmptyServerOU", []string{}, []string{"endpoint"}, nil},
+		{"MatchingOU", []string{"endpoint"}, []string{"endpoint"}, nil},
+		{"MismatchOU", []string{"endpoint"}, []string{"site"}, mkOUErr("site", "endpoint")},
+		{"NilClientOU", []string{"endpoint"}, nil, mkOUErr("", "endpoint")},
+		{"EmptyClientOU", []string{"endpoint"}, []string{}, mkOUErr("", "endpoint")},
+		{"EmptyStringClientOU", []string{"endpoint"}, []string{""}, mkOUErr("", "endpoint")},
+		{"ListOU1", []string{"endpoint", "titan"}, []string{"endpoint"}, nil},
+		{"ListOU2", []string{"endpoint", "titan"}, []string{"titan"}, nil},
+		{"ListOU3", []string{"endpoint", "titan"}, []string{"site"}, mkOUErr("site", "endpoint titan")},
 	}
 
-	for _, tc := range tests {
-		check := AllowSpecificOUandCNs{OUs: tc.AllowedOUs, CNs: nil}
-		_, err := check.CheckAuthorization(tc.ActualOUs, "")
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t2 *testing.T) {
+			check := certauth.AllowSpecificOUandCNs{OUs: tc.AllowedOUs, CNs: nil}
+			_, err := check.CheckAuthorization(tc.ActualOUs, "")
 
-		if err != nil && tc.IsAllowed {
-			t.Errorf(
-				"Expected AllowedOUs (%v) and ActualOUs (%v) "+
-					"to pass validation, but it failed: err: %s",
-				tc.AllowedOUs, tc.ActualOUs, err,
-			)
-		}
-
-		if err == nil && !tc.IsAllowed {
-			t.Errorf(
-				"Expected AllowedOUs (%v) and ActualOUs (%v) "+
-					"to fail validation, but it passed.",
-				tc.AllowedOUs, tc.ActualOUs,
-			)
-		}
+			expectErr(t2, err, tc.ExpectedErr)
+		})
 	}
 }
 
 func TestAuthValidateCN(t *testing.T) {
 	// Tests that CN validation works as expected
 	tests := []struct {
-		AllowedCNs []string
-		ActualCN   string
-		IsAllowed  bool
+		Name        string
+		AllowedCNs  []string
+		ActualCN    string
+		ExpectedErr error
 	}{
-		{[]string{}, "site1", true},
-		{[]string{"site1"}, "site1", true},
-		{[]string{"site1"}, "site", false},
-		{[]string{"site1"}, "", false},
-		{[]string{"site1", "site2"}, "site1", true},
-		{[]string{"site1", "site2"}, "site2", true},
-		{[]string{"site1", "site2"}, "site3", false},
+		{"NilServerCN", nil, "site1", nil},
+		{"EmptyServerCN", []string{}, "site1", nil},
+		{"MatchingCN", []string{"site1"}, "site1", nil},
+		{"MismatchCN", []string{"site1"}, "site", mkCNErr("site", "site1")},
+		{"EmptyClientCN", []string{"site1"}, "", mkCNErr("", "site1")},
+		{"ListCN1", []string{"site1", "site2"}, "site1", nil},
+		{"ListCN2", []string{"site1", "site2"}, "site2", nil},
+		{"ListCN3", []string{"site1", "site2"}, "site3", mkCNErr("site3", "site1 site2")},
 	}
 
 	for _, tc := range tests {
-		check := AllowSpecificOUandCNs{OUs: nil, CNs: tc.AllowedCNs}
-		_, err := check.CheckAuthorization([]string{""}, tc.ActualCN)
+		t.Run(tc.Name, func(t2 *testing.T) {
+			check := certauth.AllowSpecificOUandCNs{OUs: nil, CNs: tc.AllowedCNs}
+			_, err := check.CheckAuthorization(nil, tc.ActualCN)
 
-		if err != nil && tc.IsAllowed {
-			t.Errorf(
-				"Expected AllowedCNs (%v) and ActualCN (%v) "+
-					"to pass validation, but it failed: err: %s",
-				tc.AllowedCNs, tc.ActualCN, err,
-			)
-		}
-
-		if err == nil && !tc.IsAllowed {
-			t.Errorf(
-				"Expected AllowedCNs (%v) and ActualCN (%v) "+
-					"to fail validation, but it passed.",
-				tc.AllowedCNs, tc.ActualCN,
-			)
-		}
+			expectErr(t2, err, tc.ExpectedErr)
+		})
 	}
 }
 
-func TestAuthWithParams(t *testing.T) {
+func TestAuthCNWithParams(t *testing.T) {
 	// Tests that HasAuthorizedOU and HasAuthorizedCN are in the response
 	actualCN := "i_am_a_cn"
 	actualOU := "i_am_an_ou"
 
-	check := AllowSpecificOUandCNs{OUs: nil, CNs: []string{actualCN}}
+	check := certauth.AllowSpecificOUandCNs{OUs: nil, CNs: []string{actualCN}}
 	params, err := check.CheckAuthorization([]string{actualOU}, actualCN)
 
 	if err != nil {
-		t.Errorf(
-			"Expected AllowedCNs (%v) and ActualCN (%v) to pass validation, but it failed: err: %s",
+		t.Fatalf(
+			"Expected AllowedCNs (%v) and ActualCN (%v) to pass validation, but it failed: %s",
 			check.CNs, actualCN, err,
 		)
 	}
-	v, ok := params[HasAuthorizedCN]
+	v, ok := params[certauth.HasAuthorizedCN]
 	if !ok {
-		t.Errorf("Expected context key %q was not present %v", HasAuthorizedCN.String(), params)
-	} else if v != actualCN {
+		t.Fatalf("Expected context key %s was not present %v", certauth.HasAuthorizedCN, params)
+	}
+	if v != actualCN {
 		t.Errorf("Expected context value %q but received %q", actualCN, v)
 	}
+}
 
-	check = AllowSpecificOUandCNs{OUs: []string{actualOU}, CNs: nil}
-	params, err = check.CheckAuthorization([]string{actualOU}, actualCN)
+func TestAuthOUWithParams(t *testing.T) {
+	// Tests that HasAuthorizedOU and HasAuthorizedCN are in the response
+	actualCN := "i_am_a_cn"
+	actualOU := "i_am_an_ou"
+
+	check := certauth.AllowSpecificOUandCNs{OUs: []string{actualOU}, CNs: nil}
+	params, err := check.CheckAuthorization([]string{actualOU}, actualCN)
 
 	if err != nil {
-		t.Errorf(
-			"Expected AllowedOUs (%v) and ActualOU (%v) to pass validation, but it failed: err: %s",
+		t.Fatalf(
+			"Expected AllowedOUs (%v) and ActualOU (%v) to pass validation, but it failed: %s",
 			check.OUs, actualOU, err,
 		)
 	}
-	v, ok = params[HasAuthorizedOU]
+	v, ok := params[certauth.HasAuthorizedOU]
 	vl := v.([]string)
 	if !ok {
-		t.Errorf("Expected context key %q was not present %v", HasAuthorizedOU.String(), params)
-	} else if len(vl) != 1 || vl[0] != actualOU {
+		t.Fatalf("Expected context key %s was not present %v", certauth.HasAuthorizedOU, params)
+	}
+	if len(vl) != 1 || vl[0] != actualOU {
 		t.Errorf("Expected context value %q but received %q", actualOU, v)
 	}
 }

--- a/pantheon/pantheon_auth_test.go
+++ b/pantheon/pantheon_auth_test.go
@@ -65,10 +65,10 @@ func TestSiteAuthorization(t *testing.T) {
 		AuthorizationCheckers: pantheon_auth.PantheonSiteAuth(
 			// Only allow OUs `site` and `engineering`
 			[]string{"site", "engineering"},
-			// No restrictions on CNs
-			nil,
 			// If the OU is `site` do a site-authorization check
 			[]string{"site"},
+			// Allow the `self` site
+			true,
 		),
 	})
 
@@ -102,6 +102,7 @@ func TestSiteAuthorization(t *testing.T) {
 		},
 	)))
 
+	selfurl := "https://foo.bar" + strings.ReplaceAll(siteResource, ":site", "self")
 	site1 := "00c66762-d8ac-450b-b368-459c5d4f6aab"
 	site1url := "https://foo.bar" + strings.ReplaceAll(siteResource, ":site", site1)
 	nsite1url := "https://foo.bar" + strings.ReplaceAll(nonSiteResource, ":nosite", site1)
@@ -136,6 +137,10 @@ func TestSiteAuthorization(t *testing.T) {
 				expCode: http.StatusOK,
 				expBody: fmt.Sprintf("<none>,%s", site2),
 			},
+			selfurl: {
+				expCode: http.StatusOK,
+				expBody: fmt.Sprintf("<none>,%s", "self"),
+			},
 			nsite1url: {
 				expCode: http.StatusOK,
 				expBody: fmt.Sprintf("<none>,%s", site1),
@@ -154,6 +159,10 @@ func TestSiteAuthorization(t *testing.T) {
 				expCode: http.StatusForbidden,
 				expBody: "Authentication Failed",
 			},
+			selfurl: {
+				expCode: http.StatusOK,
+				expBody: fmt.Sprintf("%s,%s", site1, "self"),
+			},
 			nsite1url: {
 				expCode: http.StatusOK,
 				expBody: fmt.Sprintf("<none>,%s", site1),
@@ -171,6 +180,10 @@ func TestSiteAuthorization(t *testing.T) {
 			site2url: {
 				expCode: http.StatusOK,
 				expBody: fmt.Sprintf("%s,%s", site2, site2),
+			},
+			selfurl: {
+				expCode: http.StatusOK,
+				expBody: fmt.Sprintf("%s,%s", site2, "self"),
 			},
 			nsite1url: {
 				expCode: http.StatusOK,


### PR DESCRIPTION
I realized after writing a server which consumed this flow that we need to make two small modifications to make it work properly:

The first is to add an `AllowSelf` parameter which allows site authentication if the URI parameter's site is literally the word `self`. This allows clients to identify themselves with solely their client certificate. Server code can look up the `PantheonSite` in the request context to get the site ID.

The second change is a simplification by removing `allowedCNs` from the `PantheonSiteAuth` parameters. I realized this would never be used as it's behavior conflicts with that of the site authentication flow: since they both validate the contents of the `CN` in different ways, they'd only pass in the most limited of cases, which would be very limiting if a server were to use both options. So I simply removed it.

Note that the file changes in this PR include the changes from #17. Look at the most recent commit for the specific changes from this PR.