### PR TITLE
[EO-280] functional opts and "or" groups

### DIFF
--- a/certauth.go
+++ b/certauth.go
@@ -94,7 +94,9 @@ func WithErrorHandler(handler http.Handler) AuthOption {
 }
 
 func New(opts ...AuthOption) *Auth {
-	a := &Auth{}
+	a := &Auth{
+		errorHandler: http.HandlerFunc(defaultAuthErrorHandler),
+	}
 	for _, opt := range opts {
 		opt(a)
 	}

--- a/certauth.go
+++ b/certauth.go
@@ -238,9 +238,9 @@ func (a *Auth) CheckAuthorization(
 		err    error
 	)
 
-	checkers := a.checkers
+	checkers := append([][]AuthorizationChecker{}, a.checkers...)
 	if len(a.opt.AuthorizationCheckers) > 0 {
-		checkers = append(a.checkers, a.opt.AuthorizationCheckers)
+		checkers = append(checkers, a.opt.AuthorizationCheckers)
 	}
 	for _, cks := range checkers { // trying all the groups of checkers
 		for _, ck := range cks { // each checker in a group

--- a/certauth.go
+++ b/certauth.go
@@ -128,6 +128,7 @@ func NewAuth(opts ...Options) *Auth {
 	return &Auth{
 		opt:          o,
 		errorHandler: http.HandlerFunc(h),
+		checkers:     [][]AuthorizationChecker{o.AuthorizationCheckers},
 	}
 }
 
@@ -237,12 +238,7 @@ func (a *Auth) CheckAuthorization(
 		params map[ContextKey]ContextValue
 		err    error
 	)
-
-	checkers := append([][]AuthorizationChecker{}, a.checkers...)
-	if len(a.opt.AuthorizationCheckers) > 0 {
-		checkers = append(checkers, a.opt.AuthorizationCheckers)
-	}
-	for _, cks := range checkers { // trying all the groups of checkers
+	for _, cks := range a.checkers { // trying all the groups of checkers
 		for _, ck := range cks { // each checker in a group
 			if ps == nil { // not using httprouter
 				params, err = ck.CheckAuthorization(ou, cn)


### PR DESCRIPTION
- switches to functional options to configure Auth
- deprecates older factory and Options struct and preserves support
- allows passing groups of checkers to auth a request that passes all
  the checks in any one group