### PR TITLE
Allow verification of untrusted peer certs 

### DIFF
--- a/examples/untrusted_peer/main.go
+++ b/examples/untrusted_peer/main.go
@@ -1,0 +1,73 @@
+package main
+
+/*
+Example using github.com/julienschmidt/httprouter:
+
+	$ go run main.go &
+
+	$ curl -kE ../test-fixtures/client1.pem https://localhost:18080/
+	Welcome!
+
+	$ curl -kE ../test-fixtures/client2.pem https://localhost:18080/
+	Welcome!
+
+	$ curl -kE ../test-fixtures/client1.pem https://localhost:18080/hello/foo
+	hello, foo!
+
+	$ curl -kE ../test-fixtures/client2.pem https://localhost:18080/hello/foo
+	Authentication Failed
+
+	### NOTE: curl on macOS might require using the .p12 file instead of the .pem:
+	$ curl -kE ../test-fixtures/client.p12:password https://localhost:18080/
+*/
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/pantheon-systems/go-certauth"
+	"github.com/pantheon-systems/go-certauth/certutils"
+)
+
+func Index(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	fmt.Fprint(w, "Welcome!\n")
+}
+
+func Hello(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+	fmt.Fprintf(w, "hello, %s!\n", ps.ByName("name"))
+}
+
+func HelloWithoutParams(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintf(w, "hello without params")
+}
+
+func main() {
+
+	caCerts, err := certutils.LoadCACertFile("../test-fixtures/ca.crt")
+	if err != nil {
+		log.Fatalf("Unable to load ca.crt: %s", err)
+	}
+
+	auth := certauth.New(certauth.WithCheckers(certauth.AllowSpecificOUandCNs{
+		OUs: []string{"endpoint"},
+		CNs: []string{"client1"},
+	}), certauth.WithInsecureAllowUntrustedIssuer(),
+	)
+
+	router := httprouter.New()
+	router.GET("/", Index)
+	router.GET("/hello1/:name", auth.RouterHandler(Hello))
+	router.Handler("GET", "/hello2/:name", auth.Handler(http.HandlerFunc(HelloWithoutParams)))
+
+	cfg := certutils.TLSServerConfig{
+		CertPool:    caCerts,
+		BindAddress: "",
+		Port:        18080,
+		Router:      router,
+	}
+
+	server := certutils.NewTLSServer(cfg)
+	server.ListenAndServeTLS("test-fixtures/server.pem", "test-fixtures/server.pem")
+}


### PR DESCRIPTION
Current use-case:
The service fastly-config-backend is used to test changes to the GCDN
for regressions. This includes routing traffic to the correct Pantheon
region for the site, so it needs to be deployed to all our regions.
Although it isn't a production service, it runs on production kubernetes
clusters in order to have a physical presence in regions like europe. On
those clusters, the sandbox CA bundle is not available.

The Fastly services that connect to fastly-config-backend are test
services. As test services, they obtain their certificates and other
secrets from sandbox vault. Of course, this results in mTLS handshake
failures with fastly-config-backend.

Since this is only a test service used for fabricating interesting
responses, and is not in any way a part of the product, risk from an MITM
attack against it is low.

This allows the configuration of the test fastly services to obtain all
their information from only one instance of vault, significantly
simplifying the GCDN deployment machinery.