### PR TITLE
mod updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,10 +5,7 @@ version: 2.1
 executors:
   go-build:
     docker:
-      - image: quay.io/getpantheon/go-build:latest
-        auth:
-          username: $QUAY_USER
-          password: $QUAY_PASSWD
+      - image: docker.io/library/golang:1.21
 commands:
   # commands to persist and load CIRCLE_BUILD_NUM across jobs:
   save-build-num:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/pantheon-systems/go-certauth
 
-go 1.16
+go 1.21
 
 require (
-	github.com/google/uuid v1.2.0
-	github.com/julienschmidt/httprouter v1.3.1-0.20200921135023-fe77dd05ab5a
+	github.com/google/uuid v1.6.0
+	github.com/julienschmidt/httprouter v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,8 @@
 github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/julienschmidt/httprouter v1.3.1-0.20200921135023-fe77dd05ab5a h1:VTF3sHLbpm2PdWMPKVWUMwKg85VE7Ep7wgBw8ETYri8=
 github.com/julienschmidt/httprouter v1.3.1-0.20200921135023-fe77dd05ab5a/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=


### PR DESCRIPTION
- The httprouter version is invalid and is causing issues in Platform-go-sdk. Also, there's a newer version of uuid.

- Locking to go 1.21

- Pulling the executor from public go build image